### PR TITLE
Implement lock feature

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -952,6 +952,10 @@ path.oneway {
     stroke-width: 6px;
 }
 
+path.shadow.tag-locked { stroke: #FFF; }
+path.casing.tag-locked { stroke: #BBB; }
+path.stroke.tag-locked { stroke: #AAA; }
+
 /* Buildings */
 
 path.stroke.tag-building,

--- a/data/data.js
+++ b/data/data.js
@@ -14755,6 +14755,9 @@ iD.data = {
                         "5": "Great"
                     }
                 },
+                "or_lock": {
+                    "label": "Lock to prevent further edits"
+                },
                 "or_responsibility": {
                     "label": "Road responsibility",
                     "options": {

--- a/data/data.js
+++ b/data/data.js
@@ -14756,7 +14756,7 @@ iD.data = {
                     }
                 },
                 "or_lock": {
-                    "label": "Lock to prevent further edits"
+                    "label": "Lock geometry"
                 },
                 "or_responsibility": {
                     "label": "Road responsibility",

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -383,7 +383,7 @@ en:
           "4": Good
           "5": Great
       or_lock:
-        label: Lock to prevent further edits
+        label: Lock geometry
       or_responsibility:
         label: Road responsibility
         options:

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -382,6 +382,8 @@ en:
           "3": Acceptable
           "4": Good
           "5": Great
+      or_lock:
+        label: Lock to prevent further edits
       or_responsibility:
         label: Road responsibility
         options:

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -812,6 +812,11 @@
             }
         }
     },
+    "or_lock": {
+        "key": "or_lock",
+        "type": "defaultcheck",
+        "label": "Lock to prevent further edits"
+    },
     "or_responsibility": {
         "key": "or_responsibility",
         "type": "combo",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -815,7 +815,7 @@
     "or_lock": {
         "key": "or_lock",
         "type": "defaultcheck",
-        "label": "Lock to prevent further edits"
+        "label": "Lock geometry"
     },
     "or_responsibility": {
         "key": "or_responsibility",

--- a/data/presets/fields/or_lock.json
+++ b/data/presets/fields/or_lock.json
@@ -1,5 +1,5 @@
 {
     "key": "or_lock",
     "type": "defaultcheck",
-    "label": "Lock to prevent further edits"
+    "label": "Lock geometry"
 }

--- a/data/presets/fields/or_lock.json
+++ b/data/presets/fields/or_lock.json
@@ -1,0 +1,5 @@
+{
+    "key": "or_lock",
+    "type": "defaultcheck",
+    "label": "Lock to prevent further edits"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -3276,6 +3276,7 @@
     "highway/motorway": {
         "icon": "highway-motorway",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3306,6 +3307,7 @@
     "highway/motorway_link": {
         "icon": "highway-motorway-link",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3328,6 +3330,7 @@
     "highway/path": {
         "icon": "highway-path",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3371,6 +3374,7 @@
     "highway/primary": {
         "icon": "highway-primary",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3389,6 +3393,7 @@
     "highway/primary_link": {
         "icon": "highway-primary-link",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3436,6 +3441,7 @@
     "highway/residential": {
         "icon": "highway-residential",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3468,6 +3474,7 @@
     "highway/road": {
         "icon": "highway-road",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3486,6 +3493,7 @@
     "highway/secondary": {
         "icon": "highway-secondary",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3504,6 +3512,7 @@
     "highway/secondary_link": {
         "icon": "highway-secondary-link",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3526,6 +3535,7 @@
     "highway/service": {
         "icon": "highway-service",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "or_width",
@@ -3694,6 +3704,7 @@
     "highway/tertiary": {
         "icon": "highway-tertiary",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3712,6 +3723,7 @@
     "highway/tertiary_link": {
         "icon": "highway-tertiary-link",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3734,6 +3746,7 @@
     "highway/track": {
         "icon": "highway-track",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3769,6 +3782,7 @@
     "highway/trunk": {
         "icon": "highway-trunk",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3787,6 +3801,7 @@
     "highway/trunk_link": {
         "icon": "highway-trunk-link",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -3822,6 +3837,7 @@
     "highway/unclassified": {
         "icon": "highway-unclassified",
         "fields": [
+            "or_lock",
             "or_responsibility",
             "or_condition",
             "surface",
@@ -5353,6 +5369,7 @@
     "or-responsibility/commune": {
         "icon": "highway-unclassified",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",
@@ -5372,6 +5389,7 @@
     "or-responsibility/district": {
         "icon": "highway-tertiary",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",
@@ -5391,6 +5409,7 @@
     "or-responsibility/national": {
         "icon": "highway-primary",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",
@@ -5410,6 +5429,7 @@
     "or-responsibility/provincial": {
         "icon": "highway-secondary",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",
@@ -5429,6 +5449,7 @@
     "or-responsibility/special": {
         "icon": "highway-unclassified",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",
@@ -5448,6 +5469,7 @@
     "or-responsibility/urban": {
         "icon": "highway-unclassified",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",
@@ -5467,6 +5489,7 @@
     "or-responsibility/village": {
         "icon": "highway-unclassified",
         "fields": [
+            "or_lock",
             "or_condition",
             "or_width",
             "surface",

--- a/data/presets/presets/highway/motorway.json
+++ b/data/presets/presets/highway/motorway.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-motorway",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/motorway_link.json
+++ b/data/presets/presets/highway/motorway_link.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-motorway-link",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/path.json
+++ b/data/presets/presets/highway/path.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-path",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/primary.json
+++ b/data/presets/presets/highway/primary.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-primary",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/primary_link.json
+++ b/data/presets/presets/highway/primary_link.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-primary-link",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/residential.json
+++ b/data/presets/presets/highway/residential.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-residential",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/road.json
+++ b/data/presets/presets/highway/road.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-road",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/secondary.json
+++ b/data/presets/presets/highway/secondary.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-secondary",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/secondary_link.json
+++ b/data/presets/presets/highway/secondary_link.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-secondary-link",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/service.json
+++ b/data/presets/presets/highway/service.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-service",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "or_width",

--- a/data/presets/presets/highway/tertiary.json
+++ b/data/presets/presets/highway/tertiary.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-tertiary",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/tertiary_link.json
+++ b/data/presets/presets/highway/tertiary_link.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-tertiary-link",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/track.json
+++ b/data/presets/presets/highway/track.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-track",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/trunk.json
+++ b/data/presets/presets/highway/trunk.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-trunk",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/trunk_link.json
+++ b/data/presets/presets/highway/trunk_link.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-trunk-link",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/highway/unclassified.json
+++ b/data/presets/presets/highway/unclassified.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-unclassified",
     "fields": [
+        "or_lock",
         "or_responsibility",
         "or_condition",
         "surface",

--- a/data/presets/presets/or-responsibility/commune.json
+++ b/data/presets/presets/or-responsibility/commune.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-unclassified",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/data/presets/presets/or-responsibility/district.json
+++ b/data/presets/presets/or-responsibility/district.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-tertiary",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/data/presets/presets/or-responsibility/national.json
+++ b/data/presets/presets/or-responsibility/national.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-primary",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/data/presets/presets/or-responsibility/provincial.json
+++ b/data/presets/presets/or-responsibility/provincial.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-secondary",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/data/presets/presets/or-responsibility/special.json
+++ b/data/presets/presets/or-responsibility/special.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-unclassified",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/data/presets/presets/or-responsibility/urban.json
+++ b/data/presets/presets/or-responsibility/urban.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-unclassified",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/data/presets/presets/or-responsibility/village.json
+++ b/data/presets/presets/or-responsibility/village.json
@@ -1,6 +1,7 @@
 {
     "icon": "highway-unclassified",
     "fields": [
+        "or_lock",
         "or_condition",
         "or_width",
         "surface",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1111,6 +1111,9 @@
                     "5": "Great"
                 }
             },
+            "or_lock": {
+                "label": "Lock to prevent further edits"
+            },
             "or_responsibility": {
                 "label": "Road responsibility",
                 "options": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1112,7 +1112,7 @@
                 }
             },
             "or_lock": {
-                "label": "Lock to prevent further edits"
+                "label": "Lock geometry"
             },
             "or_responsibility": {
                 "label": "Road responsibility",

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -142,8 +142,35 @@ window.iD = function () {
         return history.graph().childNodes(way);
     };
 
+    context.parentWays = function(node) {
+        return history.graph().parentWays(node);
+    };
+
     context.geometry = function(id) {
         return context.entity(id).geometry(history.graph());
+    };
+
+    context.isLockedWay = function(way) {
+        return typeof way.tags === 'object' && !!way.tags.or_lock;
+    };
+
+    context.containsLockedEntity = function(ids) {
+        var all = ids.map(function(id) { return history.graph().entity(id); });
+        for (var i = 0, imax = all.length; i < imax; ++i) {
+            if (all[i].type === 'way' && context.isLockedWay(all[i])) {
+                // Return true if a way is locked.
+                return true;
+            } else if (all[i].type === 'node') {
+                // Find all the parent ways and return true if any are locked.
+                var parentWays = history.graph().parentWays(all[i]);
+                for (var k = 0, kmax = parentWays.length; k < kmax; ++k) {
+                    if (context.isLockedWay(parentWays[k])) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     };
 
     /* Modes */

--- a/js/id/modes/drag_node.js
+++ b/js/id/modes/drag_node.js
@@ -49,7 +49,8 @@ iD.modes.DragNode = function(context) {
 
     function start(entity) {
         cancelled = d3.event.sourceEvent.shiftKey ||
-            context.features().hasHiddenConnections(entity, context.graph());
+            context.features().hasHiddenConnections(entity, context.graph()) ||
+            context.containsLockedEntity([entity.id]);
 
         if (cancelled) return behavior.cancel();
 

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -142,7 +142,8 @@ iD.modes.Select = function(context, selectedIDs) {
             context.install(behavior);
         });
 
-        var operations = d3.values(iD.operations)
+        var operations = context.containsLockedEntity(selectedIDs) ? [] :
+            d3.values(iD.operations)
                 .map(function(o) { return o(selectedIDs, context); })
                 .filter(function(o) { return o.available(); });
 

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -101,7 +101,7 @@ iD.modes.Select = function(context, selectedIDs) {
             var target = d3.select(d3.event.target),
                 datum = target.datum();
 
-            if (datum instanceof iD.Way && !target.classed('fill')) {
+            if (datum instanceof iD.Way && !target.classed('fill') && !context.isLockedWay(datum)) {
                 var choice = iD.geo.chooseEdge(context.childNodes(datum), context.mouse(), context.projection),
                     node = iD.Node();
 
@@ -137,12 +137,13 @@ iD.modes.Select = function(context, selectedIDs) {
             }
         }
 
+        var lockInterface = context.containsLockedEntity(selectedIDs);
 
         behaviors.forEach(function(behavior) {
             context.install(behavior);
         });
 
-        var operations = context.containsLockedEntity(selectedIDs) ? [] :
+        var operations = lockInterface ? [] :
             d3.values(iD.operations)
                 .map(function(o) { return o(selectedIDs, context); })
                 .filter(function(o) { return o.available(); });

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -142,11 +142,9 @@ iD.modes.Select = function(context, selectedIDs) {
             context.install(behavior);
         });
 
-        var operations = _.without(d3.values(iD.operations), iD.operations.Delete)
+        var operations = d3.values(iD.operations)
                 .map(function(o) { return o(selectedIDs, context); })
                 .filter(function(o) { return o.available(); });
-
-        operations.unshift(iD.operations.Delete(selectedIDs, context));
 
         keybinding.on('⎋', function() {
             context.enter(iD.modes.Browse(context));

--- a/js/id/openroads/waytasks.js
+++ b/js/id/openroads/waytasks.js
@@ -3,7 +3,7 @@ iD.openroads.WayTasks = function(context) {
     var loadedTasks = [];
 
     exp.load = function(wayid, cb) {
-        // Search to see 
+        // Search to see
         var waytask = exp.get(wayid);
 
         if (waytask) {
@@ -77,7 +77,9 @@ iD.openroads.WayTasks = function(context) {
         // This is just client side, but since this data is removed when
         // the workers run, it's not a problem.
         _.forEach(wayids, function(wid) {
-            exp.get(wid).state = 'pending';
+            var task = exp.get(wid);
+            if (task)
+                task.state = 'pending';
         });
 
         qwest.put(context.connection().base() + '/admin/waytasks/state', {

--- a/js/id/svg/tag_classes.js
+++ b/js/id/svg/tag_classes.js
@@ -37,6 +37,10 @@ iD.svg.TagClasses = function() {
                 classes += ' tag-' + k + ' tag-' + k + '-' + v;
             }
 
+            if (t.or_lock) {
+                classes += ' tag-locked';
+            }
+
             classes = classes.trim();
 
             if (classes !== value) {


### PR DESCRIPTION
1. Adds a checkbox type lock preset.
1. Prevents the UI from showing any operations if it detects any locked entities.
1. When entities are locked, they render as grayed out.

![locks](https://user-images.githubusercontent.com/1590802/30566124-bc4342b8-9c98-11e7-81dd-633800c1b023.gif)

@mileswwatkins I tried out a couple of different approaches, but this took the least code. The bulk of the logic is in [`js/id/id.js`](https://github.com/orma/openroads-vn-iD/compare/implement-or-lock?expand=1#diff-485b3f606d12df83e22d70ea10457e4d) and should be looked at. Would also appreciate some real-life testing as well.

closes https://github.com/orma/openroads-vn-analytics/issues/74