### PR TITLE
move the tag editor up so that vprommids are immediately visible

### DIFF
--- a/js/id/ui/entity_editor.js
+++ b/js/id/ui/entity_editor.js
@@ -63,6 +63,9 @@ iD.ui.EntityEditor = function(context) {
             .append('div')
             .attr('class', 'label');
 
+        $enter.append('div')
+            .attr('class', 'inspector-border raw-tag-editor inspector-inner');
+
         $body.select('.preset-list-button-wrap')
             .call(reference.button);
 
@@ -78,8 +81,6 @@ iD.ui.EntityEditor = function(context) {
         $enter.append('div')
             .attr('class', 'raw-member-editor inspector-inner');
         
-        $enter.append('div')
-            .attr('class', 'inspector-border raw-tag-editor inspector-inner');
 
         selection.selectAll('.preset-reset')
             .on('click', function() {


### PR DESCRIPTION
fixes https://github.com/orma/openroads-vn-analytics/issues/372

![image](https://user-images.githubusercontent.com/371666/36307738-7b00c86c-1343-11e8-9662-998dc9fca3aa.png)
